### PR TITLE
`make clean` generally should remove all the build products

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,6 @@ coverage: $(LIB)
 clean:
 	rm -rf instrumented
 	rm coverage.html
+	rm -rf lib/*
 
 .PHONY: test coverage clean install


### PR DESCRIPTION
Also, seeing as this isn't yet an npm module why _are_ you committing the compiled js?
