### PR TITLE
Fixes #15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lib/coffee-script:
 	mkdir -p lib/coffee-script/
 
 lib/coffee-script/parser.js: src/grammar.pegjs lib/coffee-script
-	echo -n "module.exports = " > "$@"
+	printf %s "module.exports = " > "$@"
 	$(PEGJS) < "$<" >> "$@"
 
 lib/coffee-script/%.js: src/%.coffee lib/coffee-script


### PR DESCRIPTION
Turn echo -n into printf "%s" to make the Makefile more portable. From the echo manpage:

"Applications aiming for maximum portability are strongly encouraged to use printf(1) to suppress the newline character."
