### PR TITLE
remove `cake` from "bin" to allow npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   ],
   "main": "./lib/coffee-script/module",
   "bin": {
-    "coffee": "./bin/coffee",
-    "cake": "./bin/cake"
+    "coffee": "./bin/coffee"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Removing this until there actually is a `cake` binary allows the module to installed/linked via npm. Otherwise npm fails with:

```
npm ERR! Error: ENOENT, chmod '.../node_modules/CoffeeScriptRedux/bin/cake'
```
