### PR TITLE
* Allow whitespace before closing parens.

### DIFF
--- a/lib/coffee-script/parser.js
+++ b/lib/coffee-script/parser.js
@@ -6258,7 +6258,7 @@ module.exports = module.exports = (function(){
           return cachedResult.result;
         }
         
-        var r0, r1, r2, r3, r4, r5, r6, r7, r8;
+        var r0, r1, r2, r3, r4, r5, r6, r7, r8, r9;
         
         r0 = parse_Numbers();
         if (r0 === null) {
@@ -6394,17 +6394,23 @@ module.exports = module.exports = (function(){
                                               r7 = parse_TERMINATOR();
                                               r7 = r7 !== null ? r7 : "";
                                               if (r7 !== null) {
-                                                if (input.charCodeAt(pos.offset) === 41) {
-                                                  r8 = ")";
-                                                  advance(pos, 1);
-                                                } else {
-                                                  r8 = null;
-                                                  if (reportFailures === 0) {
-                                                    matchFailed("\")\"");
-                                                  }
-                                                }
+                                                r8 = parse__();
                                                 if (r8 !== null) {
-                                                  r0 = [r3, r4, r5, r6, r7, r8];
+                                                  if (input.charCodeAt(pos.offset) === 41) {
+                                                    r9 = ")";
+                                                    advance(pos, 1);
+                                                  } else {
+                                                    r9 = null;
+                                                    if (reportFailures === 0) {
+                                                      matchFailed("\")\"");
+                                                    }
+                                                  }
+                                                  if (r9 !== null) {
+                                                    r0 = [r3, r4, r5, r6, r7, r8, r9];
+                                                  } else {
+                                                    r0 = null;
+                                                    pos = clone(r2);
+                                                  }
                                                 } else {
                                                   r0 = null;
                                                   pos = clone(r2);
@@ -6430,11 +6436,11 @@ module.exports = module.exports = (function(){
                                         pos = clone(r2);
                                       }
                                       if (r0 !== null) {
-                                        r0 = (function(offset, line, column, ws0, e, ws1, t) {
+                                        r0 = (function(offset, line, column, ws0, e, ws1, t, ws2) {
                                             e = e.clone();
-                                            e.raw = '(' + ws0 + e.raw + ws1 + t + ')';
+                                            e.raw = '(' + ws0 + e.raw + ws1 + t + ws2 + ')';
                                             return e;
-                                          })(r1.offset, r1.line, r1.column, r4, r5, r6, r7);
+                                          })(r1.offset, r1.line, r1.column, r4, r5, r6, r7, r8);
                                       }
                                       if (r0 === null) {
                                         pos = clone(r1);

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -493,9 +493,9 @@ primaryExpression
       e.raw = '(' + t0 + e.raw + d + t1 + ')';
       return e;
     }
-  / "(" ws0:_ e:expression ws1:_ t:TERMINATOR? ")" {
+  / "(" ws0:_ e:expression ws1:_ t:TERMINATOR? ws2:_ ")" {
       e = e.clone();
-      e.raw = '(' + ws0 + e.raw + ws1 + t + ')';
+      e.raw = '(' + ws0 + e.raw + ws1 + t + ws2 + ')';
       return e;
     }
   contextVar

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -16,6 +16,10 @@ suite 'Function Literals', ->
       fn = () ->
       eq 'function', typeof fn
       eq undefined, fn()
+      fn = (->
+      )
+      eq 'function', typeof fn
+      eq undefined, fn()
 
     test 'multiple nested single-line functions', ->
       func = (x) -> (x) -> (x) -> x


### PR DESCRIPTION
This allows for:

```
# indented paren expr
->
  x = (->
  )
```

  It failed because of the two spaces before closing parens.

  Compare to this, which has always worked:

```
# non-indented paren expr
x = (->
)
```

  Also added tests for it.
