### PR TITLE
* Allow ident:: to mean ident.prototype.

### DIFF
--- a/lib/coffee-script/parser.js
+++ b/lib/coffee-script/parser.js
@@ -6234,6 +6234,26 @@ module.exports = module.exports = (function(){
                         if (r0 === null) {
                           pos = clone(r1);
                         }
+                        if (r0 === null) {
+                          r1 = clone(pos);
+                          if (input.substr(pos.offset, 2) === "::") {
+                            r0 = "::";
+                            advance(pos, 2);
+                          } else {
+                            r0 = null;
+                            if (reportFailures === 0) {
+                              matchFailed("\"::\"");
+                            }
+                          }
+                          if (r0 !== null) {
+                            r0 = (function(offset, line, column) {
+                                  return {op: CS.MemberAccessOp, operands: ["prototype"], raw: "::", line: line, column: column, offset: offset};
+                                })(r1.offset, r1.line, r1.column);
+                          }
+                          if (r0 === null) {
+                            pos = clone(r1);
+                          }
+                        }
                       }
                     }
                   }

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -473,6 +473,9 @@ memberExpression
           ws1 + (right ? right.raw + maybeRight[1] : '') + ']';
         return {op: CS.Slice, operands: [!exclusive, left, right], raw: raw, line: line, column: column, offset: offset};
       }
+    / "::" {
+        return {op: CS.MemberAccessOp, operands: ["prototype"], raw: "::", line: line, column: column, offset: offset};
+      }
 primaryExpression
   = Numbers
   / bool

--- a/test/member-access.coffee
+++ b/test/member-access.coffee
@@ -39,6 +39,7 @@ suite 'Member Access', ->
     eq undefined, nil?::b[a]
     # dynamic proto-member access
     eq nonceB, obj::[b]
+    eq nonceB, (obj::)[b]
     eq nonceB, obj?::[b]
     eq nonceA, obj?::[b].a
     eq nonceA, obj?::[b][a]


### PR DESCRIPTION
This allows for:

```
(obj::)[b]
```

  Or, more importantly:

```
ClassName = -> ...
ClassName:: = { ... }
```

  Which is frequently seen in js2coffee's output.
