### PR TITLE
Debugger statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/coffee-script/compiler.js
+++ b/lib/coffee-script/compiler.js
@@ -1695,6 +1695,12 @@ exports.Compiler = function () {
       }
     ],
     [
+      CS.Debugger,
+      function () {
+        return new JS.DebuggerStatement;
+      }
+    ],
+    [
       CS.ExpOp,
       function (param$) {
         var cache$2, left, right;

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -149,6 +149,7 @@ createNodes({
         {
           Break: null,
           Continue: null,
+          Debugger: null,
           Return: [['expression']],
           Throw: [['expression']]
         }

--- a/lib/coffee-script/optimiser.js
+++ b/lib/coffee-script/optimiser.js
@@ -249,6 +249,7 @@ mayHaveSideEffects = makeDispatcher(false, [
   [
     CS.Break,
     CS.Continue,
+    CS.Debugger,
     CS.DeleteOp,
     CS.NewOp,
     CS.Return,

--- a/lib/coffee-script/parser.js
+++ b/lib/coffee-script/parser.js
@@ -478,6 +478,9 @@ module.exports = (function(){
               r0 = parse_break();
               if (r0 === null) {
                 r0 = parse_throw();
+                if (r0 === null) {
+                  r0 = parse_debugger();
+                }
               }
             }
           }
@@ -531,6 +534,9 @@ module.exports = (function(){
               r0 = parse_break();
               if (r0 === null) {
                 r0 = parse_throw();
+                if (r0 === null) {
+                  r0 = parse_debugger();
+                }
               }
             }
           }
@@ -13808,6 +13814,32 @@ module.exports = (function(){
         return r0;
       }
       
+      function parse_debugger() {
+        var cacheKey = "debugger@" + pos.offset;
+        var cachedResult = cache[cacheKey];
+        if (cachedResult) {
+          pos = clone(cachedResult.nextPos);
+          return cachedResult.result;
+        }
+        
+        var r0, r1;
+        
+        r1 = clone(pos);
+        r0 = parse_DEBUGGER();
+        if (r0 !== null) {
+          r0 = (function(offset, line, column) { return (new CS.Debugger).r('debugger').p(line, column, offset); })(r1.offset, r1.line, r1.column);
+        }
+        if (r0 === null) {
+          pos = clone(r1);
+        }
+        
+        cache[cacheKey] = {
+          nextPos: clone(pos),
+          result:  r0
+        };
+        return r0;
+      }
+      
       function parse_undefined() {
         var cacheKey = "undefined@" + pos.offset;
         var cachedResult = cache[cacheKey];
@@ -16086,6 +16118,62 @@ module.exports = (function(){
           r3 = null;
           if (reportFailures === 0) {
             matchFailed("\"delete\"");
+          }
+        }
+        if (r3 !== null) {
+          r5 = clone(pos);
+          reportFailures++;
+          r4 = parse_identifierPart();
+          reportFailures--;
+          if (r4 === null) {
+            r4 = "";
+          } else {
+            r4 = null;
+            pos = clone(r5);
+          }
+          if (r4 !== null) {
+            r0 = [r3, r4];
+          } else {
+            r0 = null;
+            pos = clone(r2);
+          }
+        } else {
+          r0 = null;
+          pos = clone(r2);
+        }
+        if (r0 !== null) {
+          r0 = (function(offset, line, column, w) { return w; })(r1.offset, r1.line, r1.column, r3);
+        }
+        if (r0 === null) {
+          pos = clone(r1);
+        }
+        
+        cache[cacheKey] = {
+          nextPos: clone(pos),
+          result:  r0
+        };
+        return r0;
+      }
+      
+      function parse_DEBUGGER() {
+        var cacheKey = "DEBUGGER@" + pos.offset;
+        var cachedResult = cache[cacheKey];
+        if (cachedResult) {
+          pos = clone(cachedResult.nextPos);
+          return cachedResult.result;
+        }
+        
+        var r0, r1, r2, r3, r4, r5;
+        
+        r1 = clone(pos);
+        r2 = clone(pos);
+        if (input.substr(pos.offset, 8) === "debugger") {
+          r3 = "debugger";
+          advance(pos, 8);
+        } else {
+          r3 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"debugger\"");
           }
         }
         if (r3 !== null) {

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -843,6 +843,7 @@ class exports.Compiler
     [CS.Return, ({expression: e}) -> new JS.ReturnStatement expr e]
     [CS.Break, -> new JS.BreakStatement]
     [CS.Continue, -> new JS.ContinueStatement]
+    [CS.Debugger, -> new JS.DebuggerStatement]
 
     # straightforward operators
     [CS.ExpOp, ({left, right}) ->

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -136,6 +136,7 @@ statement
   / continue
   / break
   / throw
+  / debugger
 expression = expressionworthy / seqExpression
 
 secondaryStatement
@@ -144,6 +145,7 @@ secondaryStatement
   / continue
   / break
   / throw
+  / debugger
 // secondaryExpression forbids anything lower precedence than assignmentExpression
 secondaryExpression = expressionworthy / assignmentExpression
 
@@ -951,7 +953,7 @@ return
     }
 continue = CONTINUE { return (new CS.Continue).r('continue').p(line, column, offset); }
 break = BREAK { return (new CS.Break).r('break').p(line, column, offset); }
-
+debugger = DEBUGGER { return (new CS.Debugger).r('debugger').p(line, column, offset); }
 
 undefined = UNDEFINED { return (new CS.Undefined).r('undefined').p(line, column, offset); }
 null = NULL { return (new CS.Null).r('null').p(line, column, offset); }
@@ -1067,6 +1069,7 @@ CATCH = w:"catch" !identifierPart { return w; }
 CONTINUE = w:"continue" !identifierPart { return w; }
 CLASS = w:"class" !identifierPart { return w; }
 DELETE = w:"delete" !identifierPart { return w; }
+DEBUGGER = w:"debugger" !identifierPart { return w; }
 DO = w:"do" !identifierPart { return w; }
 ELSE = w:"else" !identifierPart { return w; }
 EXTENDS = w:"extends" !identifierPart { return w; }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -97,6 +97,7 @@ createNodes
       []
       Break: null # :: Break
       Continue: null # :: Continue
+      Debugger: null # :: Debugger
       Return: [['expression']] # :: Maybe Exprs -> Return
       Throw: [['expression']] # :: Exprs -> Throw
     ]

--- a/src/optimiser.coffee
+++ b/src/optimiser.coffee
@@ -84,7 +84,7 @@ mayHaveSideEffects =
       -> no
     ]
     [
-      CS.Break, CS.Continue, CS.DeleteOp, CS.NewOp, CS.Return, CS.Super
+      CS.Break, CS.Continue, CS.Debugger, CS.DeleteOp, CS.NewOp, CS.Return, CS.Super
       CS.PreDecrementOp, CS.PreIncrementOp, CS.PostDecrementOp, CS.PostIncrementOp
       CS.ClassProtoAssignOp, CS.Constructor, CS.Throw, CS.JavaScript, CS.ExtendsOp
       -> yes


### PR DESCRIPTION
Support for debugger statements.

One open question: the following seems to be valid js:

``` javascript
f = function()  {
  debugger;
}
```

However, the following is not:

``` javascript
f = function()  {
  return debugger;
}
```

Naturally this creates issues with the CS since all functions have returns at the end. Should the following CoffeeScript be a special case?

``` coffeescript
f = -> debugger
```

or should it just fail to compile? (as it currently does)
