### PR TITLE
Preprocessor error improvements.

### DIFF
--- a/src/preprocessor.coffee
+++ b/src/preprocessor.coffee
@@ -35,7 +35,11 @@ inspect = (o) -> (require 'util').inspect o, no, 9e9, yes
           'TERM'
         else
           inspect c
-    throw new Error "Unexpected " + token
+    # This isn't perfect for error location tracking, but since we normally call this after a scan, it tends to work well.
+    lines = @ss.str.substr(0, @ss.pos).split(/\n/) || ['']
+    columns = if lines[lines.length-1]? then lines[lines.length-1].length else 0
+    context = pointToErrorLocation @ss.str, lines.length, columns
+    throw new Error "Unexpected #{token}\n#{context}"
 
   peek: -> if @context.length then @context[@context.length - 1] else null
 


### PR DESCRIPTION
Improvements to errors in preprocessor. Spell out actual indentation errors, and give context.

While I thought it was weird to have functions on @context, which is an array, the primary motivation was just to make it easier to get to @ss and the things you need to do context errors easily.
