### PR TITLE
refactor binary expression parsing.

### DIFF
--- a/lib/coffee-script/parser.js
+++ b/lib/coffee-script/parser.js
@@ -1399,182 +1399,6 @@ module.exports = (function(){
         return r0;
       }
       
-      function parse_CompoundAssignmentOperators() {
-        var cacheKey = "CompoundAssignmentOperators@" + pos;
-        var cachedResult = cache[cacheKey];
-        if (cachedResult) {
-          pos = cachedResult.nextPos;
-          return cachedResult.result;
-        }
-        
-        var r0;
-        
-        if (input.substr(pos, 2) === "**") {
-          r0 = "**";
-          pos += 2;
-        } else {
-          r0 = null;
-          if (reportFailures === 0) {
-            matchFailed("\"**\"");
-          }
-        }
-        if (r0 === null) {
-          if (input.charCodeAt(pos) === 42) {
-            r0 = "*";
-            pos++;
-          } else {
-            r0 = null;
-            if (reportFailures === 0) {
-              matchFailed("\"*\"");
-            }
-          }
-          if (r0 === null) {
-            if (input.charCodeAt(pos) === 47) {
-              r0 = "/";
-              pos++;
-            } else {
-              r0 = null;
-              if (reportFailures === 0) {
-                matchFailed("\"/\"");
-              }
-            }
-            if (r0 === null) {
-              if (input.charCodeAt(pos) === 37) {
-                r0 = "%";
-                pos++;
-              } else {
-                r0 = null;
-                if (reportFailures === 0) {
-                  matchFailed("\"%\"");
-                }
-              }
-              if (r0 === null) {
-                if (input.charCodeAt(pos) === 43) {
-                  r0 = "+";
-                  pos++;
-                } else {
-                  r0 = null;
-                  if (reportFailures === 0) {
-                    matchFailed("\"+\"");
-                  }
-                }
-                if (r0 === null) {
-                  if (input.charCodeAt(pos) === 45) {
-                    r0 = "-";
-                    pos++;
-                  } else {
-                    r0 = null;
-                    if (reportFailures === 0) {
-                      matchFailed("\"-\"");
-                    }
-                  }
-                  if (r0 === null) {
-                    if (input.substr(pos, 2) === "<<") {
-                      r0 = "<<";
-                      pos += 2;
-                    } else {
-                      r0 = null;
-                      if (reportFailures === 0) {
-                        matchFailed("\"<<\"");
-                      }
-                    }
-                    if (r0 === null) {
-                      if (input.substr(pos, 3) === ">>>") {
-                        r0 = ">>>";
-                        pos += 3;
-                      } else {
-                        r0 = null;
-                        if (reportFailures === 0) {
-                          matchFailed("\">>>\"");
-                        }
-                      }
-                      if (r0 === null) {
-                        if (input.substr(pos, 2) === ">>") {
-                          r0 = ">>";
-                          pos += 2;
-                        } else {
-                          r0 = null;
-                          if (reportFailures === 0) {
-                            matchFailed("\">>\"");
-                          }
-                        }
-                        if (r0 === null) {
-                          r0 = parse_AND();
-                          if (r0 === null) {
-                            r0 = parse_OR();
-                            if (r0 === null) {
-                              if (input.substr(pos, 2) === "&&") {
-                                r0 = "&&";
-                                pos += 2;
-                              } else {
-                                r0 = null;
-                                if (reportFailures === 0) {
-                                  matchFailed("\"&&\"");
-                                }
-                              }
-                              if (r0 === null) {
-                                if (input.substr(pos, 2) === "||") {
-                                  r0 = "||";
-                                  pos += 2;
-                                } else {
-                                  r0 = null;
-                                  if (reportFailures === 0) {
-                                    matchFailed("\"||\"");
-                                  }
-                                }
-                                if (r0 === null) {
-                                  if (input.charCodeAt(pos) === 38) {
-                                    r0 = "&";
-                                    pos++;
-                                  } else {
-                                    r0 = null;
-                                    if (reportFailures === 0) {
-                                      matchFailed("\"&\"");
-                                    }
-                                  }
-                                  if (r0 === null) {
-                                    if (input.charCodeAt(pos) === 94) {
-                                      r0 = "^";
-                                      pos++;
-                                    } else {
-                                      r0 = null;
-                                      if (reportFailures === 0) {
-                                        matchFailed("\"^\"");
-                                      }
-                                    }
-                                    if (r0 === null) {
-                                      if (input.charCodeAt(pos) === 124) {
-                                        r0 = "|";
-                                        pos++;
-                                      } else {
-                                        r0 = null;
-                                        if (reportFailures === 0) {
-                                          matchFailed("\"|\"");
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        
-        cache[cacheKey] = {
-          nextPos: pos,
-          result:  r0
-        };
-        return r0;
-      }
-      
       function parse_compoundAssignmentOp() {
         var cacheKey = "compoundAssignmentOp@" + pos;
         var cachedResult = cache[cacheKey];
@@ -1583,7 +1407,7 @@ module.exports = (function(){
           return cachedResult.result;
         }
         
-        var r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12;
+        var r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13;
         
         r1 = pos;
         r2 = pos;
@@ -1591,79 +1415,102 @@ module.exports = (function(){
         if (r3 !== null) {
           r4 = parse__();
           if (r4 !== null) {
-            r5 = parse_CompoundAssignmentOperators();
-            if (r5 !== null) {
-              if (input.charCodeAt(pos) === 61) {
-                r6 = "=";
-                pos++;
-              } else {
-                r6 = null;
-                if (reportFailures === 0) {
-                  matchFailed("\"=\"");
-                }
+            r6 = pos;
+            reportFailures++;
+            if (input.charCodeAt(pos) === 63) {
+              r5 = "?";
+              pos++;
+            } else {
+              r5 = null;
+              if (reportFailures === 0) {
+                matchFailed("\"?\"");
               }
+            }
+            reportFailures--;
+            if (r5 === null) {
+              r5 = "";
+            } else {
+              r5 = null;
+              pos = r6;
+            }
+            if (r5 !== null) {
+              r6 = parse_CompoundAssignmentOperators();
               if (r6 !== null) {
-                r8 = pos;
-                r9 = pos;
-                r10 = parse_TERMINDENT();
-                if (r10 !== null) {
-                  r11 = parse_secondaryExpression();
-                  if (r11 !== null) {
-                    r12 = parse_DEDENT();
-                    if (r12 !== null) {
-                      r7 = [r10, r11, r12];
-                    } else {
-                      r7 = null;
-                      pos = r9;
-                    }
-                  } else {
-                    r7 = null;
-                    pos = r9;
-                  }
+                if (input.charCodeAt(pos) === 61) {
+                  r7 = "=";
+                  pos++;
                 } else {
                   r7 = null;
-                  pos = r9;
+                  if (reportFailures === 0) {
+                    matchFailed("\"=\"");
+                  }
                 }
                 if (r7 !== null) {
-                  reportedPos = r8;
-                  r7 = (function(e) { return e; })(r11);
-                }
-                if (r7 === null) {
-                  pos = r8;
-                }
-                if (r7 === null) {
-                  r8 = pos;
                   r9 = pos;
-                  r10 = parse_TERMINATOR();
-                  r10 = r10 !== null ? r10 : "";
-                  if (r10 !== null) {
-                    r11 = parse__();
-                    if (r11 !== null) {
-                      r12 = parse_secondaryExpression();
-                      if (r12 !== null) {
-                        r7 = [r10, r11, r12];
+                  r10 = pos;
+                  r11 = parse_TERMINDENT();
+                  if (r11 !== null) {
+                    r12 = parse_secondaryExpression();
+                    if (r12 !== null) {
+                      r13 = parse_DEDENT();
+                      if (r13 !== null) {
+                        r8 = [r11, r12, r13];
                       } else {
-                        r7 = null;
-                        pos = r9;
+                        r8 = null;
+                        pos = r10;
                       }
                     } else {
-                      r7 = null;
-                      pos = r9;
+                      r8 = null;
+                      pos = r10;
                     }
                   } else {
-                    r7 = null;
+                    r8 = null;
+                    pos = r10;
+                  }
+                  if (r8 !== null) {
+                    reportedPos = r9;
+                    r8 = (function(e) { return e; })(r12);
+                  }
+                  if (r8 === null) {
                     pos = r9;
                   }
-                  if (r7 !== null) {
-                    reportedPos = r8;
-                    r7 = (function(e) { return e; })(r12);
+                  if (r8 === null) {
+                    r9 = pos;
+                    r10 = pos;
+                    r11 = parse_TERMINATOR();
+                    r11 = r11 !== null ? r11 : "";
+                    if (r11 !== null) {
+                      r12 = parse__();
+                      if (r12 !== null) {
+                        r13 = parse_secondaryExpression();
+                        if (r13 !== null) {
+                          r8 = [r11, r12, r13];
+                        } else {
+                          r8 = null;
+                          pos = r10;
+                        }
+                      } else {
+                        r8 = null;
+                        pos = r10;
+                      }
+                    } else {
+                      r8 = null;
+                      pos = r10;
+                    }
+                    if (r8 !== null) {
+                      reportedPos = r9;
+                      r8 = (function(e) { return e; })(r13);
+                    }
+                    if (r8 === null) {
+                      pos = r9;
+                    }
                   }
-                  if (r7 === null) {
-                    pos = r8;
+                  if (r8 !== null) {
+                    r0 = [r3, r4, r5, r6, r7, r8];
+                  } else {
+                    r0 = null;
+                    pos = r2;
                   }
-                }
-                if (r7 !== null) {
-                  r0 = [r3, r4, r5, r6, r7];
                 } else {
                   r0 = null;
                   pos = r2;
@@ -1688,10 +1535,195 @@ module.exports = (function(){
           reportedPos = r1;
           r0 = (function(left, op, right) {
                 return rp(new CS.CompoundAssignOp(constructorLookup[op].prototype.className, left, right));
-              })(r3, r5, r7);
+              })(r3, r6, r8);
         }
         if (r0 === null) {
           pos = r1;
+        }
+        
+        cache[cacheKey] = {
+          nextPos: pos,
+          result:  r0
+        };
+        return r0;
+      }
+      
+      function parse_CompoundAssignmentOperators() {
+        var cacheKey = "CompoundAssignmentOperators@" + pos;
+        var cachedResult = cache[cacheKey];
+        if (cachedResult) {
+          pos = cachedResult.nextPos;
+          return cachedResult.result;
+        }
+        
+        var r0, r1, r2, r3, r4, r5;
+        
+        r1 = pos;
+        if (input.substr(pos, 2) === "&&") {
+          r0 = "&&";
+          pos += 2;
+        } else {
+          r0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"&&\"");
+          }
+        }
+        if (r0 === null) {
+          r0 = parse_AND();
+          if (r0 === null) {
+            if (input.substr(pos, 2) === "||") {
+              r0 = "||";
+              pos += 2;
+            } else {
+              r0 = null;
+              if (reportFailures === 0) {
+                matchFailed("\"||\"");
+              }
+            }
+            if (r0 === null) {
+              r0 = parse_OR();
+              if (r0 === null) {
+                if (input.substr(pos, 2) === "**") {
+                  r0 = "**";
+                  pos += 2;
+                } else {
+                  r0 = null;
+                  if (reportFailures === 0) {
+                    matchFailed("\"**\"");
+                  }
+                }
+                if (r0 === null) {
+                  if (/^[?&\^|*\/%]/.test(input.charAt(pos))) {
+                    r0 = input.charAt(pos);
+                    pos++;
+                  } else {
+                    r0 = null;
+                    if (reportFailures === 0) {
+                      matchFailed("[?&\\^|*\\/%]");
+                    }
+                  }
+                  if (r0 === null) {
+                    r2 = pos;
+                    if (input.charCodeAt(pos) === 43) {
+                      r3 = "+";
+                      pos++;
+                    } else {
+                      r3 = null;
+                      if (reportFailures === 0) {
+                        matchFailed("\"+\"");
+                      }
+                    }
+                    if (r3 !== null) {
+                      r5 = pos;
+                      reportFailures++;
+                      if (input.charCodeAt(pos) === 43) {
+                        r4 = "+";
+                        pos++;
+                      } else {
+                        r4 = null;
+                        if (reportFailures === 0) {
+                          matchFailed("\"+\"");
+                        }
+                      }
+                      reportFailures--;
+                      if (r4 === null) {
+                        r4 = "";
+                      } else {
+                        r4 = null;
+                        pos = r5;
+                      }
+                      if (r4 !== null) {
+                        r0 = [r3, r4];
+                      } else {
+                        r0 = null;
+                        pos = r2;
+                      }
+                    } else {
+                      r0 = null;
+                      pos = r2;
+                    }
+                    if (r0 === null) {
+                      r2 = pos;
+                      if (input.charCodeAt(pos) === 45) {
+                        r3 = "-";
+                        pos++;
+                      } else {
+                        r3 = null;
+                        if (reportFailures === 0) {
+                          matchFailed("\"-\"");
+                        }
+                      }
+                      if (r3 !== null) {
+                        r5 = pos;
+                        reportFailures++;
+                        if (input.charCodeAt(pos) === 45) {
+                          r4 = "-";
+                          pos++;
+                        } else {
+                          r4 = null;
+                          if (reportFailures === 0) {
+                            matchFailed("\"-\"");
+                          }
+                        }
+                        reportFailures--;
+                        if (r4 === null) {
+                          r4 = "";
+                        } else {
+                          r4 = null;
+                          pos = r5;
+                        }
+                        if (r4 !== null) {
+                          r0 = [r3, r4];
+                        } else {
+                          r0 = null;
+                          pos = r2;
+                        }
+                      } else {
+                        r0 = null;
+                        pos = r2;
+                      }
+                      if (r0 === null) {
+                        if (input.substr(pos, 2) === "<<") {
+                          r0 = "<<";
+                          pos += 2;
+                        } else {
+                          r0 = null;
+                          if (reportFailures === 0) {
+                            matchFailed("\"<<\"");
+                          }
+                        }
+                        if (r0 === null) {
+                          if (input.substr(pos, 3) === ">>>") {
+                            r0 = ">>>";
+                            pos += 3;
+                          } else {
+                            r0 = null;
+                            if (reportFailures === 0) {
+                              matchFailed("\">>>\"");
+                            }
+                          }
+                          if (r0 === null) {
+                            if (input.substr(pos, 2) === ">>") {
+                              r0 = ">>";
+                              pos += 2;
+                            } else {
+                              r0 = null;
+                              if (reportFailures === 0) {
+                                matchFailed("\">>\"");
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        if (r0 !== null) {
+          r0 = input.substring(pos, r1);
         }
         
         cache[cacheKey] = {
@@ -2006,7 +2038,7 @@ module.exports = (function(){
           return cachedResult.result;
         }
         
-        var r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12;
+        var r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13;
         
         r1 = pos;
         r2 = pos;
@@ -2014,79 +2046,102 @@ module.exports = (function(){
         if (r3 !== null) {
           r4 = parse__();
           if (r4 !== null) {
-            r5 = parse_CompoundAssignmentOperators();
-            if (r5 !== null) {
-              if (input.charCodeAt(pos) === 61) {
-                r6 = "=";
-                pos++;
-              } else {
-                r6 = null;
-                if (reportFailures === 0) {
-                  matchFailed("\"=\"");
-                }
+            r6 = pos;
+            reportFailures++;
+            if (input.charCodeAt(pos) === 63) {
+              r5 = "?";
+              pos++;
+            } else {
+              r5 = null;
+              if (reportFailures === 0) {
+                matchFailed("\"?\"");
               }
+            }
+            reportFailures--;
+            if (r5 === null) {
+              r5 = "";
+            } else {
+              r5 = null;
+              pos = r6;
+            }
+            if (r5 !== null) {
+              r6 = parse_CompoundAssignmentOperators();
               if (r6 !== null) {
-                r8 = pos;
-                r9 = pos;
-                r10 = parse_TERMINDENT();
-                if (r10 !== null) {
-                  r11 = parse_secondaryExpressionNoImplicitObjectCall();
-                  if (r11 !== null) {
-                    r12 = parse_DEDENT();
-                    if (r12 !== null) {
-                      r7 = [r10, r11, r12];
-                    } else {
-                      r7 = null;
-                      pos = r9;
-                    }
-                  } else {
-                    r7 = null;
-                    pos = r9;
-                  }
+                if (input.charCodeAt(pos) === 61) {
+                  r7 = "=";
+                  pos++;
                 } else {
                   r7 = null;
-                  pos = r9;
+                  if (reportFailures === 0) {
+                    matchFailed("\"=\"");
+                  }
                 }
                 if (r7 !== null) {
-                  reportedPos = r8;
-                  r7 = (function(e) { return e; })(r11);
-                }
-                if (r7 === null) {
-                  pos = r8;
-                }
-                if (r7 === null) {
-                  r8 = pos;
                   r9 = pos;
-                  r10 = parse_TERMINATOR();
-                  r10 = r10 !== null ? r10 : "";
-                  if (r10 !== null) {
-                    r11 = parse__();
-                    if (r11 !== null) {
-                      r12 = parse_secondaryExpressionNoImplicitObjectCall();
-                      if (r12 !== null) {
-                        r7 = [r10, r11, r12];
+                  r10 = pos;
+                  r11 = parse_TERMINDENT();
+                  if (r11 !== null) {
+                    r12 = parse_secondaryExpressionNoImplicitObjectCall();
+                    if (r12 !== null) {
+                      r13 = parse_DEDENT();
+                      if (r13 !== null) {
+                        r8 = [r11, r12, r13];
                       } else {
-                        r7 = null;
-                        pos = r9;
+                        r8 = null;
+                        pos = r10;
                       }
                     } else {
-                      r7 = null;
-                      pos = r9;
+                      r8 = null;
+                      pos = r10;
                     }
                   } else {
-                    r7 = null;
+                    r8 = null;
+                    pos = r10;
+                  }
+                  if (r8 !== null) {
+                    reportedPos = r9;
+                    r8 = (function(e) { return e; })(r12);
+                  }
+                  if (r8 === null) {
                     pos = r9;
                   }
-                  if (r7 !== null) {
-                    reportedPos = r8;
-                    r7 = (function(e) { return e; })(r12);
+                  if (r8 === null) {
+                    r9 = pos;
+                    r10 = pos;
+                    r11 = parse_TERMINATOR();
+                    r11 = r11 !== null ? r11 : "";
+                    if (r11 !== null) {
+                      r12 = parse__();
+                      if (r12 !== null) {
+                        r13 = parse_secondaryExpressionNoImplicitObjectCall();
+                        if (r13 !== null) {
+                          r8 = [r11, r12, r13];
+                        } else {
+                          r8 = null;
+                          pos = r10;
+                        }
+                      } else {
+                        r8 = null;
+                        pos = r10;
+                      }
+                    } else {
+                      r8 = null;
+                      pos = r10;
+                    }
+                    if (r8 !== null) {
+                      reportedPos = r9;
+                      r8 = (function(e) { return e; })(r13);
+                    }
+                    if (r8 === null) {
+                      pos = r9;
+                    }
                   }
-                  if (r7 === null) {
-                    pos = r8;
+                  if (r8 !== null) {
+                    r0 = [r3, r4, r5, r6, r7, r8];
+                  } else {
+                    r0 = null;
+                    pos = r2;
                   }
-                }
-                if (r7 !== null) {
-                  r0 = [r3, r4, r5, r6, r7];
                 } else {
                   r0 = null;
                   pos = r2;
@@ -2111,7 +2166,7 @@ module.exports = (function(){
           reportedPos = r1;
           r0 = (function(left, op, right) {
                 return rp(new CS.CompoundAssignOp(constructorLookup[op].prototype.className, left, right));
-              })(r3, r5, r7);
+              })(r3, r6, r8);
         }
         if (r0 === null) {
           pos = r1;
@@ -2399,25 +2454,17 @@ module.exports = (function(){
         
         r1 = pos;
         r2 = pos;
-        if (input.charCodeAt(pos) === 43) {
-          r3 = "+";
-          pos++;
-        } else {
-          r3 = null;
-          if (reportFailures === 0) {
-            matchFailed("\"+\"");
-          }
-        }
+        r3 = parse_CompoundAssignmentOperators();
         if (r3 !== null) {
           r5 = pos;
           reportFailures++;
-          if (/^[+=]/.test(input.charAt(pos))) {
-            r4 = input.charAt(pos);
+          if (input.charCodeAt(pos) === 61) {
+            r4 = "=";
             pos++;
           } else {
             r4 = null;
             if (reportFailures === 0) {
-              matchFailed("[+=]");
+              matchFailed("\"=\"");
             }
           }
           reportFailures--;
@@ -2437,258 +2484,97 @@ module.exports = (function(){
           r0 = null;
           pos = r2;
         }
-        if (r0 === null) {
-          r2 = pos;
-          if (input.charCodeAt(pos) === 45) {
-            r3 = "-";
-            pos++;
-          } else {
-            r3 = null;
-            if (reportFailures === 0) {
-              matchFailed("\"-\"");
-            }
-          }
-          if (r3 !== null) {
-            r5 = pos;
-            reportFailures++;
-            if (/^[\-=]/.test(input.charAt(pos))) {
-              r4 = input.charAt(pos);
-              pos++;
-            } else {
-              r4 = null;
-              if (reportFailures === 0) {
-                matchFailed("[\\-=]");
-              }
-            }
-            reportFailures--;
-            if (r4 === null) {
-              r4 = "";
-            } else {
-              r4 = null;
-              pos = r5;
-            }
-            if (r4 !== null) {
-              r0 = [r3, r4];
-            } else {
-              r0 = null;
-              pos = r2;
-            }
-          } else {
-            r0 = null;
-            pos = r2;
-          }
-        }
         if (r0 !== null) {
           r0 = input.substring(pos, r1);
         }
         if (r0 === null) {
-          r1 = pos;
-          r2 = pos;
-          if (input.substr(pos, 2) === "&&") {
-            r3 = "&&";
+          if (input.substr(pos, 2) === "<=") {
+            r0 = "<=";
             pos += 2;
           } else {
-            r3 = null;
-            if (reportFailures === 0) {
-              matchFailed("\"&&\"");
-            }
-          }
-          if (r3 === null) {
-            r3 = parse_AND();
-            if (r3 === null) {
-              if (input.substr(pos, 2) === "||") {
-                r3 = "||";
-                pos += 2;
-              } else {
-                r3 = null;
-                if (reportFailures === 0) {
-                  matchFailed("\"||\"");
-                }
-              }
-              if (r3 === null) {
-                r3 = parse_OR();
-                if (r3 === null) {
-                  if (input.substr(pos, 2) === "**") {
-                    r3 = "**";
-                    pos += 2;
-                  } else {
-                    r3 = null;
-                    if (reportFailures === 0) {
-                      matchFailed("\"**\"");
-                    }
-                  }
-                  if (r3 === null) {
-                    if (/^[?&\^|*\/%]/.test(input.charAt(pos))) {
-                      r3 = input.charAt(pos);
-                      pos++;
-                    } else {
-                      r3 = null;
-                      if (reportFailures === 0) {
-                        matchFailed("[?&\\^|*\\/%]");
-                      }
-                    }
-                    if (r3 === null) {
-                      if (input.substr(pos, 2) === "<<") {
-                        r3 = "<<";
-                        pos += 2;
-                      } else {
-                        r3 = null;
-                        if (reportFailures === 0) {
-                          matchFailed("\"<<\"");
-                        }
-                      }
-                      if (r3 === null) {
-                        if (input.substr(pos, 3) === ">>>") {
-                          r3 = ">>>";
-                          pos += 3;
-                        } else {
-                          r3 = null;
-                          if (reportFailures === 0) {
-                            matchFailed("\">>>\"");
-                          }
-                        }
-                        if (r3 === null) {
-                          if (input.substr(pos, 2) === ">>") {
-                            r3 = ">>";
-                            pos += 2;
-                          } else {
-                            r3 = null;
-                            if (reportFailures === 0) {
-                              matchFailed("\">>\"");
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-          if (r3 !== null) {
-            r5 = pos;
-            reportFailures++;
-            if (input.charCodeAt(pos) === 61) {
-              r4 = "=";
-              pos++;
-            } else {
-              r4 = null;
-              if (reportFailures === 0) {
-                matchFailed("\"=\"");
-              }
-            }
-            reportFailures--;
-            if (r4 === null) {
-              r4 = "";
-            } else {
-              r4 = null;
-              pos = r5;
-            }
-            if (r4 !== null) {
-              r0 = [r3, r4];
-            } else {
-              r0 = null;
-              pos = r2;
-            }
-          } else {
             r0 = null;
-            pos = r2;
-          }
-          if (r0 !== null) {
-            r0 = input.substring(pos, r1);
+            if (reportFailures === 0) {
+              matchFailed("\"<=\"");
+            }
           }
           if (r0 === null) {
-            if (input.substr(pos, 2) === "<=") {
-              r0 = "<=";
+            if (input.substr(pos, 2) === ">=") {
+              r0 = ">=";
               pos += 2;
             } else {
               r0 = null;
               if (reportFailures === 0) {
-                matchFailed("\"<=\"");
+                matchFailed("\">=\"");
               }
             }
             if (r0 === null) {
-              if (input.substr(pos, 2) === ">=") {
-                r0 = ">=";
-                pos += 2;
+              if (input.charCodeAt(pos) === 60) {
+                r0 = "<";
+                pos++;
               } else {
                 r0 = null;
                 if (reportFailures === 0) {
-                  matchFailed("\">=\"");
+                  matchFailed("\"<\"");
                 }
               }
               if (r0 === null) {
-                if (input.charCodeAt(pos) === 60) {
-                  r0 = "<";
+                if (input.charCodeAt(pos) === 62) {
+                  r0 = ">";
                   pos++;
                 } else {
                   r0 = null;
                   if (reportFailures === 0) {
-                    matchFailed("\"<\"");
+                    matchFailed("\">\"");
                   }
                 }
                 if (r0 === null) {
-                  if (input.charCodeAt(pos) === 62) {
-                    r0 = ">";
-                    pos++;
+                  if (input.substr(pos, 2) === "==") {
+                    r0 = "==";
+                    pos += 2;
                   } else {
                     r0 = null;
                     if (reportFailures === 0) {
-                      matchFailed("\">\"");
+                      matchFailed("\"==\"");
                     }
                   }
                   if (r0 === null) {
-                    if (input.substr(pos, 2) === "==") {
-                      r0 = "==";
-                      pos += 2;
-                    } else {
-                      r0 = null;
-                      if (reportFailures === 0) {
-                        matchFailed("\"==\"");
-                      }
-                    }
+                    r0 = parse_IS();
                     if (r0 === null) {
-                      r0 = parse_IS();
-                      if (r0 === null) {
-                        if (input.substr(pos, 2) === "!=") {
-                          r0 = "!=";
-                          pos += 2;
-                        } else {
-                          r0 = null;
-                          if (reportFailures === 0) {
-                            matchFailed("\"!=\"");
-                          }
+                      if (input.substr(pos, 2) === "!=") {
+                        r0 = "!=";
+                        pos += 2;
+                      } else {
+                        r0 = null;
+                        if (reportFailures === 0) {
+                          matchFailed("\"!=\"");
                         }
+                      }
+                      if (r0 === null) {
+                        r0 = parse_ISNT();
                         if (r0 === null) {
-                          r0 = parse_ISNT();
+                          r0 = parse_EXTENDS();
                           if (r0 === null) {
-                            r0 = parse_EXTENDS();
+                            r0 = parse_INSTANCEOF();
                             if (r0 === null) {
-                              r0 = parse_INSTANCEOF();
+                              r0 = parse_IN();
                               if (r0 === null) {
-                                r0 = parse_IN();
+                                r0 = parse_OF();
                                 if (r0 === null) {
-                                  r0 = parse_OF();
-                                  if (r0 === null) {
-                                    r1 = pos;
-                                    r2 = pos;
-                                    r3 = parse_NOT();
-                                    if (r3 !== null) {
-                                      r4 = parse__();
-                                      if (r4 !== null) {
-                                        r5 = parse_INSTANCEOF();
+                                  r1 = pos;
+                                  r2 = pos;
+                                  r3 = parse_NOT();
+                                  if (r3 !== null) {
+                                    r4 = parse__();
+                                    if (r4 !== null) {
+                                      r5 = parse_INSTANCEOF();
+                                      if (r5 === null) {
+                                        r5 = parse_IN();
                                         if (r5 === null) {
-                                          r5 = parse_IN();
-                                          if (r5 === null) {
-                                            r5 = parse_OF();
-                                          }
+                                          r5 = parse_OF();
                                         }
-                                        if (r5 !== null) {
-                                          r0 = [r3, r4, r5];
-                                        } else {
-                                          r0 = null;
-                                          pos = r2;
-                                        }
+                                      }
+                                      if (r5 !== null) {
+                                        r0 = [r3, r4, r5];
                                       } else {
                                         r0 = null;
                                         pos = r2;
@@ -2697,13 +2583,16 @@ module.exports = (function(){
                                       r0 = null;
                                       pos = r2;
                                     }
-                                    if (r0 !== null) {
-                                      reportedPos = r1;
-                                      r0 = (function(op) { return 'not ' + op;  })(r5);
-                                    }
-                                    if (r0 === null) {
-                                      pos = r1;
-                                    }
+                                  } else {
+                                    r0 = null;
+                                    pos = r2;
+                                  }
+                                  if (r0 !== null) {
+                                    reportedPos = r1;
+                                    r0 = (function(op) { return 'not ' + op;  })(r5);
+                                  }
+                                  if (r0 === null) {
+                                    pos = r1;
                                   }
                                 }
                               }
@@ -19225,9 +19114,7 @@ module.exports = (function(){
       var CS = require("./nodes"),
       
         constructorLookup =
-          { ';': CS.SeqOp
-          , '=': CS.AssignOp
-          , '||': CS.LogicalOrOp
+          { '||': CS.LogicalOrOp
           , or: CS.LogicalOrOp
           , '&&': CS.LogicalAndOp
           , and: CS.LogicalAndOp
@@ -19260,13 +19147,10 @@ module.exports = (function(){
       
         negatableOps = ['instanceof', 'in', 'of'],
         chainableComparisonOps = ['<=', '>=', '<', '>', '==', 'is', '!=', 'isnt'],
-        compoundAssignableOps = ['**',  '*',  '/',  '%',  '+',  '-',  '<<',  '>>>',  '>>',  'and',  'or',  '&&', '||',  '&',  '^',  '|'],
       
         rightAssocOps = [';', '=', '?', '**'],
         precedenceHierarchy =
-          [ [';']
-          , ['=']
-          , ['or', '||']
+          [ ['or', '||']
           , ['and', '&&']
           , ['|']
           , ['^']
@@ -19316,16 +19200,6 @@ module.exports = (function(){
             precedenceTable[negatedOp] = precedenceTable[op];
             associativities[negatedOp] = associativities[op];
           }(negatableOps[i]));
-        }
-      
-        for(var i = 0, l = compoundAssignableOps.length; i < l; ++i) {
-          (function(op){
-            var assignmentOp = op + '=';
-            constructorLookup[assignmentOp] = function(left, right){ return new CS.CompoundAssignOp(op, left, right); };
-            constructorLookup[assignmentOp].prototype = CS.CompoundAssignOp.prototype;
-            precedenceTable[assignmentOp] = precedenceTable['='];
-            associativities[assignmentOp] = associativities['='];
-          }(compoundAssignableOps[i]));
         }
       
       
@@ -19385,8 +19259,8 @@ module.exports = (function(){
                     nextPrec = precedenceTable[nextOp];
                     prec = precedenceTable[operator];
                   }
-                } while(nextOp != null && (nextPrec > prec || chainableComparisonOps.indexOf(nextOp) >= 0));
                 // TODO: I would love `a < b is c < d` to instead denote `(a < b) is (c < d)`
+                } while(nextOp != null && (nextPrec > prec || chainableComparisonOps.indexOf(nextOp) >= 0));
                 stack.push(new CS.ChainedComparisonOp(foldBinaryExpr(chainStack, true)));
                 continue;
               }


### PR DESCRIPTION
Fixes #112. Chained comparison handling really muddied up `foldBinaryExpr`, unfortunately. Performance appears to have been improved by only around 5%. Still, the grammar itself is much smaller and DRY-er. Assignment and compound assignments still need to be pulled into `foldBinaryExpr`, but they should be much easier than chained comparison handling.
