### PR TITLE
Update installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ wiki page.
 ### Development
 
     git clone git://github.com/michaelficarra/CoffeeScriptRedux.git
-    make clean && git co lib && make -j build && make test
+    npm install && make clean && git checkout lib && make -j build && make test
 
 ### Notable Contributors
 


### PR DESCRIPTION
You have to `npm install` in order to grab the npm dependencies.
`git co` alias does not exist by default. Using `git checkout` instead
