### PR TITLE
changes parser so that 'class' can be an object key

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -627,11 +627,11 @@ module.exports = (function(){
                   if (r0 === null) {
                     r0 = parse_forIn();
                     if (r0 === null) {
-                      r0 = parse_class();
+                      r0 = parse_switch();
                       if (r0 === null) {
-                        r0 = parse_switch();
+                        r0 = parse_implicitObjectLiteral();
                         if (r0 === null) {
-                          r0 = parse_implicitObjectLiteral();
+                          r0 = parse_class();
                         }
                       }
                     }

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -346,9 +346,9 @@ expressionworthy
   / try
   / forOf
   / forIn
-  / class
   / switch
   / implicitObjectLiteral
+  / class
 
 
 seqExpression

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -283,3 +283,29 @@ suite 'Object Literals', ->
       eq 2, obj.c.a
       eq 3, obj.c.b
       eq 4, obj.d
+
+    test '#258: object literals with a key named class', ->
+      a = class: 'b'
+      eq 'b', a.class
+
+    test '#259: object literals inside a class with a key named class', ->
+      class Bar
+        a: false
+        render: (x) ->
+          'rendered: ' + x
+
+      class Foo extends Bar
+        foo: 'bar'
+        attributes:
+          class: 'c'
+        render: ->
+          Bar::render.apply(this, arguments)
+
+      otherRender = ->
+        Bar::render.apply(this, arguments)
+
+      f = new Foo
+
+      eq f.attributes.class, 'c'
+      eq f.render('baz'), 'rendered: baz'
+      eq otherRender('baz'), 'rendered: baz'


### PR DESCRIPTION
This patch fixes the following two issues:

https://github.com/michaelficarra/CoffeeScriptRedux/issues/258
https://github.com/michaelficarra/CoffeeScriptRedux/issues/259
