### PR TITLE
CLI args should not be caught by coffee if executing a script

### DIFF
--- a/test/cli-files/cli-options.coffee
+++ b/test/cli-files/cli-options.coffee
@@ -1,0 +1,2 @@
+process.stdout.write 'test -v ok' if process.argv[2] is '-v'
+process.stdout.write 'test -r ok' if process.argv[2] is '-r'

--- a/test/cli.coffee
+++ b/test/cli.coffee
@@ -1,0 +1,23 @@
+exec = require('child_process').exec
+
+suite 'Command line execution', ->
+
+  test 'CLI options without any executable should be handled by CoffeeScript', (done) ->
+    exec 'bin/coffee -v', (error, stdout, stderr) ->
+      pkg = require './../package.json'
+      ok(stdout.toString().indexOf "CoffeeScript version #{pkg.version}" is 0)
+
+      done()
+
+
+  test 'Known CLI options should be passed to script if executable was specified', (done) ->
+    exec 'bin/coffee test/cli-files/cli-options.coffee -v', (error, stdout, stderr) ->
+      eq stdout, 'test -v ok'
+
+      done()
+
+  test 'Unknown CLI options should be passed to script if executable was specified', (done) ->
+    exec 'bin/coffee test/cli-files/cli-options.coffee -r', (error, stdout, stderr) ->
+      eq stdout, 'test -r ok'
+
+      done()


### PR DESCRIPTION
CoffeeScript currently intercepts and handles command-line arguments which it can respond to, like -v and -h. It does this even if I execute a script file, i.e.

``` bash
coffee myfile.coffee -v
CoffeeScript version 2.0.0-beta7
```

I would expect CoffeeScript to simply pass such arguments to the script being run. Currently, if my script is a command-line tool that is expected to show help messages on -h argument it will never execute.

I have managed to write a couple of test cases that demonstrate the problem, but I am not as skilled as to provide an actual patch.

Thanks for your help!
