### PR TITLE
Fix #250: Splats shouldn’t increase function length

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -184,9 +184,10 @@ makeReturn = function (node) {
   }
 };
 generateMutatingWalker = function (fn) {
-  return function (node, args) {
+  return function (node) {
     var childName, n;
-    args = 2 <= arguments.length ? [].slice.call(arguments, 1) : [];
+    var args;
+    args = arguments.length > 1 ? [].slice.call(arguments, 1) : [];
     for (var i$ = 0, length$ = node.childNodes.length; i$ < length$; ++i$) {
       childName = node.childNodes[i$];
       if (!(null != node[childName]))
@@ -1152,12 +1153,12 @@ exports.Compiler = function () {
           parameters = parameters_.reverse();
           if (parameters.length > 0) {
             if (parameters.slice(-1)[0].rest) {
+              paramName = parameters.pop().expression;
               numParams = parameters.length;
-              paramName = parameters[numParams - 1] = parameters[numParams - 1].expression;
-              test = new JS.BinaryExpression('<=', new JS.Literal(numParams), memberAccess(new JS.Identifier('arguments'), 'length'));
-              consequent = helpers.slice(new JS.Identifier('arguments'), new JS.Literal(numParams - 1));
+              test = new JS.BinaryExpression('>', memberAccess(new JS.Identifier('arguments'), 'length'), new JS.Literal(numParams));
+              consequent = helpers.slice(new JS.Identifier('arguments'), new JS.Literal(numParams));
               alternate = new JS.ArrayExpression([]);
-              block.body.unshift(stmt(new JS.AssignmentExpression('=', paramName, new JS.ConditionalExpression(test, consequent, alternate))));
+              block.body.unshift(makeVarDeclaration([paramName]), stmt(new JS.AssignmentExpression('=', paramName, new JS.ConditionalExpression(test, consequent, alternate))));
             } else if (any(parameters, function (p) {
                 return p.rest;
               })) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -161,8 +161,9 @@ envEnrichments_ = function (inScope) {
   }.call(this));
   return difference(possibilities, inScope);
 };
-this.envEnrichments = envEnrichments = function (node, args) {
-  args = 2 <= arguments.length ? [].slice.call(arguments, 1) : [];
+this.envEnrichments = envEnrichments = function (node) {
+  var args;
+  args = arguments.length > 1 ? [].slice.call(arguments, 1) : [];
   if (null != node) {
     return envEnrichments_.apply(node, args);
   } else {

--- a/lib/js-nodes.js
+++ b/lib/js-nodes.js
@@ -22,9 +22,10 @@ this.Nodes = Nodes = function () {
   function Nodes() {
   }
   Nodes.prototype.listMembers = [];
-  Nodes.prototype['instanceof'] = function (ctors) {
+  Nodes.prototype['instanceof'] = function () {
     var ctor;
-    ctors = 1 <= arguments.length ? [].slice.call(arguments, 0) : [];
+    var ctors;
+    ctors = arguments.length > 0 ? [].slice.call(arguments, 0) : [];
     for (var i$ = 0, length$ = ctors.length; i$ < length$; ++i$) {
       ctor = ctors[i$];
       if (!(this.type === ctor.prototype.type))

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -428,9 +428,10 @@ Nodes.prototype.clone = function () {
   }
   return n;
 };
-Nodes.prototype['instanceof'] = function (ctors) {
+Nodes.prototype['instanceof'] = function () {
   var ctor, superclasses;
-  ctors = 1 <= arguments.length ? [].slice.call(arguments, 0) : [];
+  var ctors;
+  ctors = arguments.length > 0 ? [].slice.call(arguments, 0) : [];
   superclasses = map(this.constructor.superclasses, function (c) {
     return c.prototype.className;
   });
@@ -457,8 +458,9 @@ Nodes.prototype.g = function () {
   this.generated = true;
   return this;
 };
-handlePrimitives = function (ctor, primitives) {
-  primitives = 2 <= arguments.length ? [].slice.call(arguments, 1) : [];
+handlePrimitives = function (ctor) {
+  var primitives;
+  primitives = arguments.length > 1 ? [].slice.call(arguments, 1) : [];
   ctor.prototype.childNodes = difference(ctor.prototype.childNodes, primitives);
   return ctor.prototype.toBasicObject = function () {
     var obj, primitive;
@@ -480,8 +482,9 @@ handlePrimitives(Range, 'isInclusive');
 handlePrimitives(RegExp, 'data', 'flags');
 handlePrimitives(Slice, 'isInclusive');
 handlePrimitives(StaticMemberAccessOps, 'memberName');
-handleLists = function (ctor, listProps) {
-  listProps = 2 <= arguments.length ? [].slice.call(arguments, 1) : [];
+handleLists = function (ctor) {
+  var listProps;
+  listProps = arguments.length > 1 ? [].slice.call(arguments, 1) : [];
   return ctor.prototype.listMembers = listProps;
 };
 handleLists(ArrayInitialiser, 'members');

--- a/lib/optimiser.js
+++ b/lib/optimiser.js
@@ -34,8 +34,9 @@ makeDispatcher = function (defaultValue, handlers, defaultHandler) {
       handlers_[ctor.prototype.className] = handler;
     }
   }
-  return function (node, args) {
-    args = 2 <= arguments.length ? [].slice.call(arguments, 1) : [];
+  return function (node) {
+    var args;
+    args = arguments.length > 1 ? [].slice.call(arguments, 1) : [];
     if (!(null != node))
       return defaultValue;
     handler = Object.prototype.hasOwnProperty.call(handlers_, node.className) ? handlers_[node.className] : defaultHandler;

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -630,12 +630,12 @@ class exports.Compiler
 
         if parameters.length > 0
           if parameters[-1..][0].rest
+            paramName = parameters.pop().expression
             numParams = parameters.length
-            paramName = parameters[numParams - 1] = parameters[numParams - 1].expression
-            test = new JS.BinaryExpression '<=', (new JS.Literal numParams), memberAccess (new JS.Identifier 'arguments'), 'length'
-            consequent = helpers.slice (new JS.Identifier 'arguments'), new JS.Literal (numParams - 1)
+            test = new JS.BinaryExpression '>', (memberAccess (new JS.Identifier 'arguments'), 'length'), new JS.Literal numParams
+            consequent = helpers.slice (new JS.Identifier 'arguments'), new JS.Literal numParams
             alternate = new JS.ArrayExpression []
-            block.body.unshift stmt new JS.AssignmentExpression '=', paramName, new JS.ConditionalExpression test, consequent, alternate
+            block.body.unshift (makeVarDeclaration [paramName]), stmt new JS.AssignmentExpression '=', paramName, new JS.ConditionalExpression test, consequent, alternate
           else if any parameters, (p) -> p.rest
             paramName = index = null
             for p, i in parameters when p.rest

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -87,6 +87,12 @@ suite 'Function Literals', ->
     #  arrayEq [0, 1], (((splat..., _, _1) -> splat) 0, 1, 2, 3)
     #  arrayEq [2], (((_, _1, splat..., _2) -> splat) 0, 1, 2, 3)
 
+    test "function length with splats", ->
+      eq 0, ((splat...) ->).length
+      eq 2, ((_, _1, splat...) ->).length
+      eq 2, ((splat..., _, _1) ->).length
+      eq 3, ((_, _1, splat..., _2) ->).length
+
     #test "destructured splatted parameters", ->
     #  arr = [0,1,2]
     #  splatArray = ([a...]) -> a


### PR DESCRIPTION
ES6 rest parameters do not contribute to the `length` property of
functions.

Before CSR didn’t either, except when the last parameter was a splat.
