### PR TITLE
Reenable literate formating test case

### DIFF
--- a/test/literate.coffee
+++ b/test/literate.coffee
@@ -1,7 +1,6 @@
 suite 'Literate Formatting', ->
 
-  # This test passes in node 0.8, but has some infinite recursion issue outside this code in 0.10
-  # So I've disabled it until the issue gets magically resolved at some point in the future
-  #test 'jashkenas/coffee-script: src/scope.litcoffee', ->
-  #  litcoffee = "#{fs.readFileSync 'test/scope.litcoffee'}"
-  #  parse litcoffee, literate: yes
+  test 'jashkenas/coffee-script: src/scope.litcoffee', ->
+    litcoffee = "#{fs.readFileSync 'test/scope.litcoffee'}"
+    parse litcoffee, literate: yes
+

--- a/test/scope.litcoffee
+++ b/test/scope.litcoffee
@@ -7,7 +7,7 @@ with external scopes.
 
 Import the helpers we plan to use.
 
-    {extend, last} = require './helpers'
+    #{extend, last} = require './helpers'
 
     exports.Scope = class Scope
 
@@ -114,3 +114,4 @@ of this scope.
 
       assignedVariables: ->
         "#{v.name} = #{v.type.value}" for v in @variables when v.type.assigned
+


### PR DESCRIPTION
I think the literate test case is magically resolved, and hence should be added back into the test suite.
