### PR TITLE
fix browser build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,14 @@ dist:
 
 dist/coffee-script-redux.js: lib/browser.js dist
 	$(CJSIFY) src/browser.coffee -vx CoffeeScript \
+		-a fs: -a child_process: \
 		-a /src/register.coffee: \
 		-a /src/parser.coffee:/lib/parser.js \
 		--source-map "$@.map" > "$@"
 
 dist/coffee-script-redux.min.js: lib/browser.js dist
 	$(CJSIFY) src/browser.coffee -vmx CoffeeScript \
+		-a fs: -a child_process: \
 		-a /src/register.coffee: \
 		-a /src/parser.coffee:/lib/parser.js \
 		--source-map "$@.map" > "$@"


### PR DESCRIPTION
Browser build was failing for me due to missing core modules:

```
required "fs" from "path"

/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/lib/command.js:167
        throw e;
              ^
Error: Core module "fs" has not yet been ported to the browser
    at resolvePath (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/lib/relative-resolve.js:30:15)
    at module.exports (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/lib/relative-resolve.js:62:16)
    at Controller.estraverse.replace.enter (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/lib/traverse-dependencies.js:108:24)
    at Controller.__execute (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/node_modules/estraverse/estraverse.js:313:31)
    at Controller.replace (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/node_modules/estraverse/estraverse.js:488:27)
    at Object.replace (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/node_modules/estraverse/estraverse.js:556:27)
    at Object.module.exports [as traverseDependencies] (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/lib/traverse-dependencies.js:93:18)
    at build (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/lib/command.js:149:31)
    at startBuild (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/lib/command.js:220:17)
    at Object.<anonymous> (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/lib/command.js:271:5)
    at Object.<anonymous> (/Users/ghempton/projects/oss/CoffeeScriptRedux/node_modules/commonjs-everywhere/lib/command.js:282:3)
```