### PR TITLE
output ast in parse mode to file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -36,6 +36,8 @@ esmangle = function () {
   }
 }.call(this);
 inspect = function (o) {
+  if (options.output)
+    return JSON.stringify(o, null, 2);
   return require('util').inspect(o, false, 9e9, true);
 };
 knownOpts = {};

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -12,7 +12,11 @@ cscodegen = try require 'cscodegen'
 escodegen = try require 'escodegen'
 esmangle = try require 'esmangle'
 
-inspect = (o) -> (require 'util').inspect o, no, 9e9, yes
+inspect = (o) -> 
+  
+  if options.output then return JSON.stringify o, null, 2
+
+  (require 'util').inspect o, no, 9e9, yes
 
 knownOpts = {}
 option = -> knownOpts[o] = Boolean for o in arguments; return


### PR DESCRIPTION
allow parse option of cli to return data to output file without using inspect with colors by returning a stringified version of the abstract sintax tree
