### PR TITLE
Support Windows line ending after backslash (continuation line) in array literal

### DIFF
--- a/src/preprocessor.coffee
+++ b/src/preprocessor.coffee
@@ -173,6 +173,8 @@ StringScanner = require 'StringScanner'
             @introduceContext()
 
         when '\\'
+          # skip CR for Windows compatibility
+          @ss.scan /[\r]/
           if (@scan /[\s\S]/) then @observe 'end-\\'
           # TODO: somehow prevent indent tokens from being inserted after these newlines
         when '"""'

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -61,6 +61,9 @@ suite 'Parser', ->
   test 'windows line endings', ->
     @shouldParse 'if test\r\n  fn a\r\n\r\n  fn b'
 
+  test 'indentation on explicit continuation line in array literal after windows line ending', ->
+    @shouldParse 'call 1, [2, \\\r\n  3]'
+
   test 'strip leading spaces in heredocs', ->
     eq 'a\n  b\nc', '''
       a


### PR DESCRIPTION
As noted in #328, a line continuation backslash followed by a windows newline causes the preprocessor to bail out.

This isn't unique to array literals, of course, but that's the driving use case for me.
