### PR TITLE
Ensure string interpolation segments have `raw' values.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -19656,6 +19656,7 @@ module.exports = (function() {
             if (left instanceof CS.String) {
               if (left === init) {
                 c(left, s);
+                left.raw = s.raw;
                 delete left.generated;
               }
               left.data = '' + left.data + s.data;

--- a/src/grammar.pegcoffee
+++ b/src/grammar.pegcoffee
@@ -170,6 +170,7 @@
           if left instanceof CS.String
             if left is init
               c left, s
+              left.raw = s.raw
               delete left.generated
             left.data = "#{left.data}#{s.data}"
             return memo

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -164,6 +164,11 @@ suite 'Parser', ->
       ast = parse '0x0', raw: yes
       eq '0x0', ast.body.statements[0].raw
 
+    test 'strings', ->
+      ast = parse '"aaaaaa#{bbbbbb}cccccc"', raw: yes
+      eq 'aaaaaa', ast.body.statements[0].left.left.raw
+      eq 'cccccc', ast.body.statements[0].right.raw
+
   suite 'position/offset preservation', ->
 
     test 'basic indentation', ->


### PR DESCRIPTION
This addresses part of #335, specifically the [`raw` and `range` properties being missing in the first segment of a string interpolation](https://github.com/michaelficarra/CoffeeScriptRedux/issues/335#issuecomment-70351888).