### PR TITLE
Ensure string interpolations with empty prefixes have raw values.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -19647,7 +19647,7 @@ module.exports = (function() {
     };
     createInterpolation = function (es) {
       var init;
-      init = new CS.String('').g();
+      init = new CS.String('').g().r('');
       return foldl(function (memo, s) {
         var left;
         if (s instanceof CS.String) {

--- a/src/grammar.pegcoffee
+++ b/src/grammar.pegcoffee
@@ -162,7 +162,7 @@
     expr
 
   createInterpolation = (es) ->
-    init = new CS.String('').g()
+    init = new CS.String('').g().r('')
     foldl ((memo, s) ->
       if s instanceof CS.String
         left = memo

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -169,6 +169,10 @@ suite 'Parser', ->
       eq 'aaaaaa', ast.body.statements[0].left.left.raw
       eq 'cccccc', ast.body.statements[0].right.raw
 
+    test 'empty string interpolation prefix', ->
+      ast = parse '"#{0}"', raw: yes
+      eq '', ast.body.statements[0].left.raw
+
   suite 'position/offset preservation', ->
 
     test 'basic indentation', ->


### PR DESCRIPTION
Without this the string node that is the left of the ConcatOp has no
raw value, which is unexpected when parsing with `raw: true`.