### PR TITLE
Avoid a crash when no raw

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -652,7 +652,7 @@ exports.Compiler = function () {
   Compiler.compile = function (this$) {
     return function () {
       var cache$2;
-      return (cache$2 = new this$).compile.apply(cache$2, [].slice.call(arguments));
+      return (cache$2 = new this$()).compile.apply(cache$2, [].slice.call(arguments));
     };
   }(Compiler);
   defaultRules = [
@@ -1605,7 +1605,7 @@ exports.Compiler = function () {
           return expr(compile(generateSoak(this)));
         } else {
           access = memberAccess(expression, this.memberName);
-          if (this.raw) {
+          if (this.raw && this.expression.raw) {
             access.property.raw = this.memberName;
             access.property.line = this.line;
             offset = this.raw.length - this.memberName.length;

--- a/lib/optimiser.js
+++ b/lib/optimiser.js
@@ -387,7 +387,7 @@ exports.Optimiser = function () {
   Optimiser.optimise = function (this$) {
     return function () {
       var cache$2;
-      return (cache$2 = new this$).optimise.apply(cache$2, [].slice.call(arguments));
+      return (cache$2 = new this$()).optimise.apply(cache$2, [].slice.call(arguments));
     };
   }(Optimiser);
   Optimiser.isTruthy = isTruthy;

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -862,7 +862,7 @@ class exports.Compiler
       else
         access = memberAccess expression, @memberName
         # manually calculate raw/position info for member name
-        if @raw
+        if @raw and @expression.raw
           access.property.raw = @memberName
           access.property.line = @line
           offset = @raw.length - @memberName.length


### PR DESCRIPTION
You can make the compiler crash by trying to compile this file:

```coffee
argv[2..-1].join()
```

like this:

```
/bin/coffee --js --input sample.coffee --source-map-file sample.map
```

This change defends against the missing `expression.raw`, since I'm inferring from the surrounding code that `raw` is not always present on every node.